### PR TITLE
update the name of the stderr output and clean up

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -66,19 +66,20 @@ jobs:
         run: |
           set +e
           <% if (pnpm) { %>
-          pnpm release-plan prepare 2> >(tee -a stderr.log >&2)
+          pnpm release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
           <% } else { %>
-          npx release-plan prepare 2> >(tee -a stderr.log >&2)
+          npx release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
           <% } %>
 
           if [ $? -ne 0 ]; then
             echo 'text<<EOF' >> $GITHUB_OUTPUT
-            cat stderr.log >> $GITHUB_OUTPUT
+            cat release-plan-stderr.txt >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
           else
             echo 'text<<EOF' >> $GITHUB_OUTPUT
             jq .description .release-plan.json -r >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
+            rm release-plan-stderr.txt
           fi
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This prevents anyone who has a .gitignore file catching any *.log files from having issues where the PR isn't created when the release-plan fails. Essentially the peter-evans/create-pull-request action needs a file change to open the PR and we leave the release-plan-stderr.txt in the output when we have a failure to make sure the PR is created.

This PR also make sure to clean up the release-plan-stderr.txt when the plan succeeds

Fixes https://github.com/embroider-build/create-release-plan-setup/issues/88
Already in use here: https://github.com/embroider-build/embroider/pull/1871