### PR TITLE
Support updating release plan when labels are changed on previously-merged PRs

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -4,9 +4,10 @@ on:
     branches:
       - main
       - master
-  pull_request:
+  pull_request_target: # This workflow has permissions on the repo, do NOT run code from PRs in this workflow. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     types:
       - labeled
+      - unlabeled
 
 concurrency:
   group: plan-release # only the latest one of these should ever be running
@@ -41,7 +42,7 @@ jobs:
       explanation: ${{ steps.explanation.outputs.text }}
     # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
     # only run on labeled event if the PR has already been merged
-    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Using the `pull_request` event to trigger the workflow when labels are added on PRs from forks runs into permissions issues when the workflow attempts to open or update the release plan PR. This is because PR workflows from forks do not get repo secrets.

The `pull_request_target` event allows triggering a workflow upon an event on a PR from a fork but does include the secrets. It is not safe to run code from the PR in this workflow and the workflow that runs is from the base branch. Since this workflow only pulls the primary branch, this is safe to use. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

This can be seen working here: 

https://github.com/kategengler/test-rp-new/pull/1

Action that ran when the label was changed on the PR https://github.com/kategengler/test-rp-new/actions/runs/9684295098

