### PR TITLE
Add issue read permission to action

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -37,6 +37,7 @@ jobs:
     needs: check-plan
     permissions:
       contents: write
+      issues: read
       pull-requests: write
     outputs:
       explanation: ${{ steps.explanation.outputs.text }}


### PR DESCRIPTION
I discovered that this was needed when setting up release-plan in a private repo. For public repos, anyone can read so this isn't necessary.