### PR TITLE
fix provenance for pnpm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: npm publish
-        run: pnpm release-plan publish --provenance
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/publish-template.yml.ejs
+++ b/publish-template.yml.ejs
@@ -55,7 +55,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: npm publish
-        run: pnpm release-plan publish --provenance<% } else { %>
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish<% } else { %>
       - run: npm ci
       - name: npm publish
         run: npx release-plan publish --provenance<% } %>


### PR DESCRIPTION
Apparently passing `--provenance` to `pnpm publish` does nothing 🙈 but you can override the behaviour by passing `NPM_CONFIG_PROVENANCE: true` as an ENV variable

See https://github.com/pnpm/pnpm/issues/6607#issuecomment-2075092418