### PR TITLE
Update the publish template to make use of `paths` filtering in github workflows

### DIFF
--- a/publish-template.yml.ejs
+++ b/publish-template.yml.ejs
@@ -1,6 +1,5 @@
-# For every push to the master branch, this checks if the release-plan was
-# updated and if it was it will publish stable npm packages based on the
-# release plan
+# For every push to the primary branch with .release-plan.json modified,
+# runs release-plan.
 
 name: Publish Stable
 
@@ -10,34 +9,17 @@ on:
     branches:
       - main
       - master
+    paths:
+      - '.release-plan.json'
 
 concurrency:
   group: publish-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check-plan:
-    name: "Check Release Plan"
-    runs-on: ubuntu-latest
-    outputs:
-      command: ${{ steps.check-release.outputs.command }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: '<%= defaultBranch %>'
-      # This will only cause the `check-plan` job to have a result of `success`
-      # when the .release-plan.json file was changed on the last commit. This
-      # plus the fact that this action only runs on main will be enough of a guard
-      - id: check-release
-        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
-
   publish:
     name: "NPM Publish"
     runs-on: ubuntu-latest
-    needs: check-plan
-    if: needs.check-plan.outputs.command == 'release'
     permissions:
       contents: write
       pull-requests: write
@@ -56,10 +38,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'<% if (pnpm) { %>
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: npm publish
+      - name: Publish to NPM
         run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish<% } else { %>
       - run: npm ci
-      - name: npm publish
+      - name: Publish to NPM
         run: npx release-plan publish --provenance<% } %>
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Minor rewording of `npm publish` title for the call to release plan so it does not look like a command being run

Confirmed to work in https://github.com/kategengler/test-release-plan/