### PR TITLE
Update the Plan Release template to include the version for single packages in the PR title and in the commit message.

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -1,5 +1,6 @@
-name: Release Plan Review
+name: Plan Release
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -14,8 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-plan:
-    name: "Check Release Plan"
+  is-this-a-release:
+    name: "Is this a release?"
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check-release.outputs.command }}
@@ -23,27 +24,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
           ref: '<%= defaultBranch %>'
-      # This will only cause the `check-plan` job to have a "command" of `release`
+      # This will only cause the `is-this-a-release` job to have a "command" of `release`
       # when the .release-plan.json file was changed on the last commit.
       - id: check-release
         run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
 
-  prepare-release-notes:
-    name: Prepare Release Notes
+  create-prepare-release-pr:
+    name: Create Prepare Release PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: check-plan
+    needs: is-this-a-release
     permissions:
       contents: write
       issues: read
       pull-requests: write
-    outputs:
-      explanation: ${{ steps.explanation.outputs.text }}
-    # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
+    # only run on push event or workflow dispatch if plan wasn't updated (don't create a release plan when we're releasing)
     # only run on labeled event if the PR has already been merged
-    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
+    if: ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.is-this-a-release.outputs.command != 'release') || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
 
     steps:
       - uses: actions/checkout@v4
@@ -69,24 +68,28 @@ jobs:
           npx release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)<% } %>
 
           if [ $? -ne 0 ]; then
-            echo 'text<<EOF' >> $GITHUB_OUTPUT
-            cat release-plan-stderr.txt >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
+            release_plan_output=$(cat release-plan-stderr.txt)
           else
-            echo 'text<<EOF' >> $GITHUB_OUTPUT
-            jq .description .release-plan.json -r >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
+            release_plan_output=$(jq .description .release-plan.json -r)
             rm release-plan-stderr.txt
+
+            if [ $(jq '.solution | length' .release-plan.json) -eq 1 ]; then
+              new_version=$(jq -r '.solution[].newVersion' .release-plan.json)
+              echo "new_version=v$new_version" >> $GITHUB_OUTPUT
+            fi
           fi
+            echo 'text<<EOF' >> $GITHUB_OUTPUT
+          echo "$release_plan_output" >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "Prepare Release using 'release-plan'"
+          commit-message: "Prepare Release ${{ steps.explanation.outputs.new_version}} using 'release-plan'"
           labels: "internal"
           branch: release-preview
-          title: Prepare Release
+          title: Prepare Release ${{ steps.explanation.outputs.new_version }}
           body: |
             This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
 


### PR DESCRIPTION
Additionally:

- Add workflow_dispatch to allow the release plan to be triggered
- Change fetch_depth on the release plan check to the required depth of 2
- Some renaming of jobs and steps to make things more easy to read

Can be seen in use https://github.com/kategengler/test-release-plan/