### PR TITLE
Don't do a full install just to run the release-plan prepare

### DIFF
--- a/plan-release-template.yml.ejs
+++ b/plan-release-template.yml.ejs
@@ -51,22 +51,16 @@ jobs:
         # github-changelog can discover what's changed since the last release
         with:
           fetch-depth: 0
-          ref: '<%= defaultBranch %>'<% if (pnpm) { %>
-      - uses: pnpm/action-setup@v4<% if (!hasPackageManager) { %>
-        with:
-          version: 9<% } %><% } %>
+          ref: '<%= defaultBranch %>'
       - uses: actions/setup-node@v4
         with:
-          node-version: 18<% if (pnpm) { %>
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile<% } else { %>
-      - run: npm ci<% } %>
+          node-version: 18
+      - run: npm install -g release-plan
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
-          set +e<% if (pnpm) { %>
-          pnpm release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)<% } else { %>
-          npx release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)<% } %>
+          set +e
+          release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
 
           if [ $? -ne 0 ]; then
             echo 'text<<EOF' >> $GITHUB_OUTPUT


### PR DESCRIPTION
Afaict installing all the dependencies to run `release-plan prepare` is unnecessary